### PR TITLE
Adding stub Travis CI configuration file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+ - "2.7"
+install: "pip install -r requirements.txt"
+# **REMEMBER TO FIX THAT AFTER ADDING UNIT TESTING**
+script: echo "This is a stub configuration"


### PR DESCRIPTION
So, this changeset will just **shut** Travis CI's mouth. 

This is just a stub configuration, so do change that after the introduction of unit testing.
